### PR TITLE
Update prompts to enforce React import

### DIFF
--- a/app/lib/common/prompts/prompts.ts
+++ b/app/lib/common/prompts/prompts.ts
@@ -497,6 +497,8 @@ ULTRA IMPORTANT: Think first and reply with the artifact that contains all neces
   8. For photos:
        - Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
 
+  9. For any React code, start each file with `import React from 'react';` to prevent errors.
+
   EXPO CONFIGURATION:
 
   1. Define app configuration in app.json:

--- a/app/lib/common/prompts/prompts.ts
+++ b/app/lib/common/prompts/prompts.ts
@@ -497,7 +497,7 @@ ULTRA IMPORTANT: Think first and reply with the artifact that contains all neces
   8. For photos:
        - Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
 
-  9. For any React code, start each file with `import React from 'react';` to prevent errors.
+  9. For any React code, start each file with \`import React from 'react';\` to prevent errors.
 
   EXPO CONFIGURATION:
 


### PR DESCRIPTION
## Summary
- add React import guideline to prompts

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684857c77740832b9233518a680bcfd7