### PR TITLE
Implement start page with Start button

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -214,10 +214,14 @@ export const ChatImpl = memo(
     });
     useEffect(() => {
       const prompt = searchParams.get('prompt');
+      const start = searchParams.get('start');
 
       // console.log(prompt, searchParams, model, provider);
 
-      if (prompt) {
+      if (start) {
+        setSearchParams({});
+        runAnimation();
+      } else if (prompt) {
         setSearchParams({});
         runAnimation();
         append({

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,6 @@
 import { json, type MetaFunction } from '@remix-run/cloudflare';
 import { ClientOnly } from 'remix-utils/client-only';
+import { useNavigate, useSearchParams } from '@remix-run/react';
 import { BaseChat } from '~/components/chat/BaseChat';
 import { Chat } from '~/components/chat/Chat.client';
 import { Header } from '~/components/header/Header';
@@ -18,6 +19,28 @@ export const loader = () => json({});
  * to keep the UI clean and consistent with the design system.
  */
 export default function Index() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const started = searchParams.get('start');
+
+  if (!started) {
+    return (
+      <div className="flex flex-col h-full w-full bg-bolt-elements-background-depth-1">
+        <BackgroundRays />
+        <Header />
+        <div className="flex flex-col flex-1 items-center justify-center text-center px-4">
+          <h1 className="text-3xl lg:text-6xl font-bold text-bolt-elements-textPrimary mb-4">Create with no limits</h1>
+          <p className="text-md lg:text-xl mb-8 text-bolt-elements-textSecondary">
+            Describe what you want with words, no code.
+          </p>
+          <button onClick={() => navigate('?start=1')} className="px-6 py-2 rounded-md bg-accent text-white">
+            Start
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col h-full w-full bg-bolt-elements-background-depth-1">
       <BackgroundRays />


### PR DESCRIPTION
## Summary
- add a start page with "Create with no limits" message
- show chat interface after clicking Start via `?start=1`
- handle the `start` query parameter to start the chat

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6848863745c8832bba9d05eaaf96bcc1