### PR TITLE
Remove white background rays

### DIFF
--- a/app/components/ui/BackgroundRays/styles.module.scss
+++ b/app/components/ui/BackgroundRays/styles.module.scss
@@ -26,7 +26,9 @@
   }
 }
 
+
 .lightRay {
+  display: none;
   position: absolute;
   border-radius: 100%;
 


### PR DESCRIPTION
## Summary
- hide the background 'rays' effect

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b1ab05f0832b8b6d19a19779ef1a