### PR TITLE
Update starter templates line

### DIFF
--- a/app/components/chat/StarterTemplates.tsx
+++ b/app/components/chat/StarterTemplates.tsx
@@ -23,9 +23,9 @@ const FrameworkLink: React.FC<FrameworkLinkProps> = ({ template }) => (
 const StarterTemplates: React.FC = () => {
   return (
     <div className="flex flex-col items-center gap-4">
-      <span className="text-sm text-gray-500">or start a blank app with your favorite stack</span>
+      <span className="text-sm text-gray-500">Launch a new project using your go-to stack.</span>
       <div className="flex justify-center">
-        <div className="flex flex-wrap justify-center items-center gap-4 max-w-sm">
+        <div className="flex flex-nowrap justify-center items-center gap-4">
           {STARTER_TEMPLATES.map((template) => (
             <FrameworkLink key={template.name} template={template} />
           ))}


### PR DESCRIPTION
## Summary
- update header text for starter templates section
- keep framework icons on a single line

## Testing
- `pnpm run test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6848c7e9e928832b84a1fc4beabc5b63