### PR TITLE
Update StarterTemplates text and layout

### DIFF
--- a/app/components/chat/StarterTemplates.tsx
+++ b/app/components/chat/StarterTemplates.tsx
@@ -23,9 +23,9 @@ const FrameworkLink: React.FC<FrameworkLinkProps> = ({ template }) => (
 const StarterTemplates: React.FC = () => {
   return (
     <div className="flex flex-col items-center gap-4">
-      <span className="text-sm text-gray-500">or start a blank app with your favorite stack</span>
+      <span className="text-sm text-gray-500">Launch a new project using your go-to stack</span>
       <div className="flex justify-center">
-        <div className="flex flex-wrap justify-center items-center gap-4 max-w-sm">
+        <div className="flex justify-center items-center gap-4 overflow-x-auto whitespace-nowrap">
           {STARTER_TEMPLATES.map((template) => (
             <FrameworkLink key={template.name} template={template} />
           ))}


### PR DESCRIPTION
## Summary
- tweak call-to-action wording for starter templates
- fix icons layout to a single line

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@blitz/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6848cdf45a70832baec21a6d23e901e8