### PR TITLE
Add gradient text intro

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -14,6 +14,7 @@ import { getApiKeysFromCookies } from './APIKeyManager';
 import Cookies from 'js-cookie';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import styles from './BaseChat.module.scss';
+import { GradientText } from '~/components/ui';
 import { ImportButtons } from '~/components/chat/chatExportAndImport/ImportButtons';
 import { ExamplePrompts } from '~/components/chat/ExamplePrompts';
 import GitCloneButton from './GitCloneButton';
@@ -333,9 +334,14 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
           <div className={classNames(styles.Chat, 'flex flex-col flex-grow lg:min-w-[var(--chat-min-width)] h-full')}>
             {!chatStarted && (
               <div id="intro" className="mt-[16vh] max-w-chat mx-auto text-center px-4 lg:px-0">
-                <h1 className="text-3xl lg:text-6xl font-bold text-bolt-elements-textPrimary mb-4 animate-fade-in">
+                <GradientText
+                  colors={["#40ffaa", "#4079ff", "#40ffaa", "#4079ff", "#40ffaa"]}
+                  animationSpeed={3}
+                  showBorder={false}
+                  className="text-3xl lg:text-6xl font-bold mb-4 animate-fade-in"
+                >
                   Create with no limits
-                </h1>
+                </GradientText>
                 <p className="text-md lg:text-xl mb-8 text-bolt-elements-textSecondary animate-fade-in animation-delay-200">
                   Describe what you want with words, no code.
                 </p>

--- a/app/components/ui/GradientText.module.scss
+++ b/app/components/ui/GradientText.module.scss
@@ -1,0 +1,66 @@
+.animatedGradientText {
+  position: relative;
+  margin: 0 auto;
+  display: flex;
+  max-width: fit-content;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1.25rem;
+  font-weight: 500;
+  backdrop-filter: blur(10px);
+  transition: box-shadow 0.5s ease-out;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.gradientOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-size: 300% 100%;
+  animation: gradient linear infinite;
+  border-radius: inherit;
+  z-index: 0;
+  pointer-events: none;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: calc(100% - 2px);
+    height: calc(100% - 2px);
+    transform: translate(-50%, -50%);
+    border-radius: inherit;
+    background-color: #060010;
+    z-index: -1;
+  }
+}
+
+.textContent {
+  display: inline-block;
+  position: relative;
+  z-index: 2;
+  background-size: 300% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: gradient linear infinite;
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  50% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0% 50%;
+  }
+}

--- a/app/components/ui/GradientText.tsx
+++ b/app/components/ui/GradientText.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { classNames } from '~/utils/classNames';
+import styles from './GradientText.module.scss';
+
+interface GradientTextProps {
+  children: React.ReactNode;
+  className?: string;
+  colors?: string[];
+  animationSpeed?: number;
+  showBorder?: boolean;
+}
+
+export function GradientText({
+  children,
+  className = '',
+  colors = ['#40ffaa', '#4079ff', '#40ffaa', '#4079ff', '#40ffaa'],
+  animationSpeed = 8,
+  showBorder = false,
+}: GradientTextProps) {
+  const gradientStyle: React.CSSProperties = {
+    backgroundImage: `linear-gradient(to right, ${colors.join(', ')})`,
+    animationDuration: `${animationSpeed}s`,
+  };
+
+  return (
+    <div className={classNames(styles.animatedGradientText, className)}>
+      {showBorder && <div className={styles.gradientOverlay} style={gradientStyle} />}
+      <div className={styles.textContent} style={gradientStyle}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -27,6 +27,7 @@ export * from './EmptyState';
 export * from './FileIcon';
 export * from './FilterChip';
 export * from './GradientCard';
+export * from './GradientText';
 export * from './RepositoryStats';
 export * from './SearchInput';
 export * from './SearchResultItem';


### PR DESCRIPTION
## Summary
- add `GradientText` component with animated gradient effect
- export component from UI bundle
- use `GradientText` for "Create with no limits" in chat intro

## Testing
- `pnpm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `pnpm run test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6848eaf3591c832bbb68a29ec3fa51f8