### PR TITLE
Darken chat box and related elements

### DIFF
--- a/app/components/@settings/core/AvatarDropdown.tsx
+++ b/app/components/@settings/core/AvatarDropdown.tsx
@@ -35,7 +35,7 @@ export const AvatarDropdown = ({ onSelectTab }: AvatarDropdownProps) => {
               decoding="sync"
             />
           ) : (
-            <div className="w-full h-full rounded-full flex items-center justify-center bg-white dark:bg-gray-800 text-gray-400 dark:text-gray-500">
+            <div className="w-full h-full rounded-full flex items-center justify-center bg-white dark:bg-gray-900 text-gray-400 dark:text-gray-500">
               <div className="i-ph:question w-6 h-6" />
             </div>
           )}
@@ -61,7 +61,7 @@ export const AvatarDropdown = ({ onSelectTab }: AvatarDropdownProps) => {
               'border-b border-gray-200/50 dark:border-gray-800/50',
             )}
           >
-            <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0 bg-white dark:bg-gray-800 shadow-sm">
+            <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0 bg-white dark:bg-gray-900 shadow-sm">
               {profile?.avatar ? (
                 <img
                   src={profile.avatar}

--- a/app/components/@settings/shared/components/TabTile.tsx
+++ b/app/components/@settings/shared/components/TabTile.tsx
@@ -55,7 +55,7 @@ export const TabTile: React.FC<TabTileProps> = ({
                   'w-14 h-14',
                   'flex items-center justify-center',
                   'rounded-xl',
-                  'bg-gray-100 dark:bg-gray-800',
+                  'bg-gray-100 dark:bg-gray-900',
                   'ring-1 ring-gray-200 dark:ring-gray-700',
                   'group-hover:bg-purple-100 dark:group-hover:bg-gray-700/80',
                   'group-hover:ring-purple-200 dark:group-hover:ring-purple-800/30',

--- a/app/components/@settings/tabs/event-logs/EventLogsTab.tsx
+++ b/app/components/@settings/tabs/event-logs/EventLogsTab.tsx
@@ -145,7 +145,7 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
           {details.prompt && (
             <div className="flex flex-col gap-1">
               <div className="text-xs font-medium text-gray-700 dark:text-gray-300">Prompt:</div>
-              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded p-2 whitespace-pre-wrap">
+              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded p-2 whitespace-pre-wrap">
                 {details.prompt}
               </pre>
             </div>
@@ -153,7 +153,7 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
           {details.response && (
             <div className="flex flex-col gap-1">
               <div className="text-xs font-medium text-gray-700 dark:text-gray-300">Response:</div>
-              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded p-2 whitespace-pre-wrap">
+              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded p-2 whitespace-pre-wrap">
                 {details.response}
               </pre>
             </div>
@@ -176,7 +176,7 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
           {details.request && (
             <div className="flex flex-col gap-1">
               <div className="text-xs font-medium text-gray-700 dark:text-gray-300">Request:</div>
-              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded p-2 whitespace-pre-wrap">
+              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded p-2 whitespace-pre-wrap">
                 {JSON.stringify(details.request, null, 2)}
               </pre>
             </div>
@@ -184,7 +184,7 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
           {details.response && (
             <div className="flex flex-col gap-1">
               <div className="text-xs font-medium text-gray-700 dark:text-gray-300">Response:</div>
-              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded p-2 whitespace-pre-wrap">
+              <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded p-2 whitespace-pre-wrap">
                 {JSON.stringify(details.response, null, 2)}
               </pre>
             </div>
@@ -202,7 +202,7 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
     }
 
     return (
-      <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded whitespace-pre-wrap">
+      <pre className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded whitespace-pre-wrap">
         {JSON.stringify(details, null, 2)}
       </pre>
     );
@@ -242,7 +242,7 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
                 {log.level}
               </div>
               {log.category && (
-                <div className="px-2 py-0.5 rounded-full text-xs bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+                <div className="px-2 py-0.5 rounded-full text-xs bg-gray-100 dark:bg-gray-900 text-gray-500 dark:text-gray-400">
                   {log.category}
                 </div>
               )}

--- a/app/components/@settings/tabs/profile/ProfileTab.tsx
+++ b/app/components/@settings/tabs/profile/ProfileTab.tsx
@@ -69,7 +69,7 @@ export default function ProfileTab() {
             <div
               className={classNames(
                 'w-24 h-24 rounded-full overflow-hidden',
-                'bg-gray-100 dark:bg-gray-800/50',
+                'bg-gray-100 dark:bg-gray-900/50',
                 'flex items-center justify-center',
                 'ring-1 ring-gray-200 dark:ring-gray-700',
                 'relative group',
@@ -137,7 +137,7 @@ export default function ProfileTab() {
                 onChange={(e) => handleProfileUpdate('username', e.target.value)}
                 className={classNames(
                   'w-full pl-11 pr-4 py-2.5 rounded-xl',
-                  'bg-white dark:bg-gray-800/50',
+                  'bg-white dark:bg-gray-900/50',
                   'border border-gray-200 dark:border-gray-700/50',
                   'text-gray-900 dark:text-white',
                   'placeholder-gray-400 dark:placeholder-gray-500',
@@ -161,7 +161,7 @@ export default function ProfileTab() {
                 onChange={(e) => handleProfileUpdate('bio', e.target.value)}
                 className={classNames(
                   'w-full pl-11 pr-4 py-2.5 rounded-xl',
-                  'bg-white dark:bg-gray-800/50',
+                  'bg-white dark:bg-gray-900/50',
                   'border border-gray-200 dark:border-gray-700/50',
                   'text-gray-900 dark:text-white',
                   'placeholder-gray-400 dark:placeholder-gray-500',

--- a/app/components/@settings/tabs/providers/service-status/ServiceStatusTab.tsx
+++ b/app/components/@settings/tabs/providers/service-status/ServiceStatusTab.tsx
@@ -104,7 +104,7 @@ export default function ServiceStatusTab() {
         {serviceStatuses.map((service) => (
           <div
             key={service.provider}
-            className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+            className="p-4 bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700"
           >
             <div className="flex items-center justify-between mb-2">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{service.provider}</h3>

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -59,7 +59,7 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
   return (
     <div
       className={classNames(
-        'relative bg-gray-800 text-gray-200 p-2 rounded-md border border-[#444] w-full max-w-chat mx-auto z-prompt',
+        'relative bg-gray-900 text-gray-200 p-2 rounded-md border border-[#444] w-full max-w-chat mx-auto z-prompt',
 
         /*
          * {
@@ -117,7 +117,7 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
         )}
       </ClientOnly>
       <div
-        className={classNames('relative border border-[#444] rounded-md bg-gray-800')}
+        className={classNames('relative border border-[#444] rounded-md bg-gray-900')}
       >
         <textarea
           ref={props.textareaRef}
@@ -265,8 +265,8 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
           </div>
           {props.input.length > 3 ? (
             <div className="text-xs text-gray-400">
-              Use <kbd className="kdb px-1.5 py-0.5 rounded bg-gray-800">Shift</kbd> +{' '}
-              <kbd className="kdb px-1.5 py-0.5 rounded bg-gray-800">Return</kbd> a new line
+              Use <kbd className="kdb px-1.5 py-0.5 rounded bg-gray-900">Shift</kbd> +{' '}
+              <kbd className="kdb px-1.5 py-0.5 rounded bg-gray-900">Return</kbd> a new line
             </div>
           ) : null}
           <SupabaseConnection />

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -76,7 +76,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
                   })}
                 >
                   {isUserMessage && (
-                    <div className="flex items-center justify-center w-[40px] h-[40px] overflow-hidden bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-500 rounded-full shrink-0 self-start">
+                    <div className="flex items-center justify-center w-[40px] h-[40px] overflow-hidden bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-500 rounded-full shrink-0 self-start">
                       {profile?.avatar ? (
                         <img
                           src={profile.avatar}

--- a/app/components/sidebar/HistoryItem.tsx
+++ b/app/components/sidebar/HistoryItem.tsx
@@ -68,8 +68,8 @@ export function HistoryItem({
   return (
     <div
       className={classNames(
-        'group rounded-lg text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50/80 dark:hover:bg-gray-800/30 overflow-hidden flex justify-between items-center px-3 py-2 transition-colors',
-        { 'text-gray-900 dark:text-white bg-gray-50/80 dark:bg-gray-800/30': isActiveChat },
+        'group rounded-lg text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50/80 dark:hover:bg-gray-900/30 overflow-hidden flex justify-between items-center px-3 py-2 transition-colors',
+        { 'text-gray-900 dark:text-white bg-gray-50/80 dark:bg-gray-900/30': isActiveChat },
         { 'cursor-pointer': selectionMode },
       )}
       onClick={selectionMode ? handleItemClick : undefined}

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -327,7 +327,7 @@ export const Menu = () => {
             <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
               {profile?.username || 'Guest User'}
             </span>
-            <div className="flex items-center justify-center w-[32px] h-[32px] overflow-hidden bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-500 rounded-full shrink-0">
+            <div className="flex items-center justify-center w-[32px] h-[32px] overflow-hidden bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-500 rounded-full shrink-0">
               {profile?.avatar ? (
                 <img
                   src={profile.avatar}
@@ -359,7 +359,7 @@ export const Menu = () => {
                   'flex gap-1 items-center rounded-lg px-3 py-2 transition-colors',
                   selectionMode
                     ? 'bg-accent-600 dark:bg-accent-500 text-white border border-accent-700 dark:border-accent-600'
-                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700',
+                    : 'bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700',
                 )}
                 aria-label={selectionMode ? 'Exit selection mode' : 'Enter selection mode'}
               >

--- a/app/components/ui/Dialog.tsx
+++ b/app/components/ui/Dialog.tsx
@@ -26,7 +26,7 @@ export const DialogButton = memo(({ type, children, onClick, disabled }: DialogB
         type === 'primary'
           ? 'bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-500 dark:hover:bg-purple-600'
           : type === 'secondary'
-            ? 'bg-transparent text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100'
+            ? 'bg-transparent text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100'
             : 'bg-transparent text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10',
       )}
       onClick={onClick}


### PR DESCRIPTION
## Summary
- tweak chat box styling to use `bg-gray-900`
- update shared components using the same gray tone

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684912ed9678832bb85e4683fd3e0066