### PR TITLE
Rename Bolt Terminal

### DIFF
--- a/app/components/workbench/terminal/TerminalTabs.tsx
+++ b/app/components/workbench/terminal/TerminalTabs.tsx
@@ -107,7 +107,7 @@ export const TerminalTabs = memo(() => {
                       onClick={() => setActiveTerminal(index)}
                     >
                       <div className="i-ph:terminal-window-duotone text-lg" />
-                      Bolt Terminal
+                      Rubtle Terminal
                     </button>
                   ) : (
                     <React.Fragment>


### PR DESCRIPTION
## Summary
- rename `Bolt Terminal` to `Rubtle Terminal`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68491ac59694832b8aec9d062208394b