### PR TITLE
Remove light mode

### DIFF
--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -2,7 +2,6 @@ import { motion, type Variants } from 'framer-motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
-import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
 import { Button } from '~/components/ui/Button';
 import { db, deleteById, getAll, chatId, type ChatHistoryItem, useChatHistory } from '~/lib/persistence';
 import { cubicEasingFn } from '~/utils/easings';
@@ -507,9 +506,6 @@ export const Menu = () => {
                 )}
               </Dialog>
             </DialogRoot>
-          </div>
-          <div className="flex items-center justify-end border-t border-gray-200 dark:border-gray-800 px-4 py-3">
-            <ThemeSwitch />
           </div>
         </div>
       </motion.div>

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -13,7 +13,6 @@ export * from './Label';
 export * from './ScrollArea';
 export * from './Switch';
 export * from './Tabs';
-export * from './ThemeSwitch';
 
 // Loading components
 export * from './LoadingDots';

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -9,7 +9,6 @@ import type {
 } from '~/components/@settings/core/types';
 import { DEFAULT_TAB_CONFIG } from '~/components/@settings/core/constants';
 import Cookies from 'js-cookie';
-import { toggleTheme } from './theme';
 import { create } from 'zustand';
 
 export interface Shortcut {
@@ -25,7 +24,6 @@ export interface Shortcut {
 }
 
 export interface Shortcuts {
-  toggleTheme: Shortcut;
   toggleTerminal: Shortcut;
 }
 
@@ -36,15 +34,6 @@ export type ProviderSetting = Record<string, IProviderConfig>;
 
 // Simplified shortcuts store with only theme toggle
 export const shortcutsStore = map<Shortcuts>({
-  toggleTheme: {
-    key: 'd',
-    metaKey: true,
-    altKey: true,
-    shiftKey: true,
-    action: () => toggleTheme(),
-    description: 'Toggle theme',
-    isPreventDefault: true,
-  },
   toggleTerminal: {
     key: '`',
     ctrlOrMetaKey: true,

--- a/app/lib/stores/theme.ts
+++ b/app/lib/stores/theme.ts
@@ -9,7 +9,7 @@ export function themeIsDark() {
   return themeStore.get() === 'dark';
 }
 
-export const DEFAULT_THEME = 'light';
+export const DEFAULT_THEME = 'dark';
 
 export const themeStore = atom<Theme>(initStore());
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -42,17 +42,7 @@ export const links: LinksFunction = () => [
 ];
 
 const inlineThemeCode = stripIndents`
-  setTutorialKitTheme();
-
-  function setTutorialKitTheme() {
-    let theme = localStorage.getItem('bolt_theme');
-
-    if (!theme) {
-      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-
-    document.querySelector('html')?.setAttribute('data-theme', theme);
-  }
+  document.querySelector('html')?.setAttribute('data-theme', 'dark');
 `;
 
 export const Head = createHead(() => (


### PR DESCRIPTION
## Summary
- drop theme switch from sidebar menu
- default theme to dark
- simplify theme initialization
- clean up unused theme shortcuts and exports

## Testing
- `npm run lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684920dc1480832bbffb533ad0070326