### PR TITLE
Add noise overlay to background

### DIFF
--- a/app/components/ui/BackgroundRays/styles.module.scss
+++ b/app/components/ui/BackgroundRays/styles.module.scss
@@ -24,6 +24,24 @@
   :global(html[data-theme='light']) & {
     mix-blend-mode: multiply;
   }
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at center, rgba(128, 128, 128, 0.2), rgba(0, 0, 0, 0.7));
+    pointer-events: none;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='200' height='200' filter='url(%23n)' /></svg>");
+    opacity: 0.35;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- overlay grey gradient and noise textures on background rays

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint plugin)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6849229ebcf8832b9c30e6d4e9e8d1c1