### PR TITLE
Add follow file toggle

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -81,6 +81,7 @@ export const Workbench = memo(
     const unsavedFiles = useStore(workbenchStore.unsavedFiles);
     const files = useStore(workbenchStore.files);
     const selectedView = useStore(workbenchStore.currentView);
+    const followFileUpdates = useStore(workbenchStore.followFileUpdates);
 
     const isSmallViewport = useViewport(1024);
 
@@ -173,6 +174,15 @@ export const Workbench = memo(
                   <div className="ml-auto" />
                   {selectedView === 'code' && (
                     <div className="flex overflow-y-auto">
+                      <PanelHeaderButton
+                        className="mr-1 text-sm"
+                        onClick={() => {
+                          workbenchStore.toggleFollowFileUpdates();
+                        }}
+                      >
+                        <div className={`i-ph:${followFileUpdates ? 'eye' : 'eye-slash'}`} />
+                        Follow File
+                      </PanelHeaderButton>
                       <PanelHeaderButton
                         className="mr-1 text-sm"
                         onClick={() => {


### PR DESCRIPTION
## Summary
- allow disabling automatic file focus while streaming code
- expose follow file toggle in Workbench header

## Testing
- `pnpm test` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6849258d5f7c832ba01ec3c0143c31cf