### PR TITLE
Replace Bolt references with Rubtle

### DIFF
--- a/app/components/chat/ChatAlert.tsx
+++ b/app/components/chat/ChatAlert.tsx
@@ -14,8 +14,8 @@ export default function ChatAlert({ alert, clearAlert, postMessage }: Props) {
   const isPreview = source === 'preview';
   const title = isPreview ? 'Preview Error' : 'Terminal Error';
   const message = isPreview
-    ? 'We encountered an error while running the preview. Would you like Bolt to analyze and help resolve this issue?'
-    : 'We encountered an error while running terminal commands. Would you like Bolt to analyze and help resolve this issue?';
+    ? 'We encountered an error while running the preview. Would you like Rubtle to analyze and help resolve this issue?'
+    : 'We encountered an error while running terminal commands. Would you like Rubtle to analyze and help resolve this issue?';
 
   return (
     <AnimatePresence>
@@ -84,7 +84,7 @@ export default function ChatAlert({ alert, clearAlert, postMessage }: Props) {
                   )}
                 >
                   <div className="i-ph:chat-circle-duotone"></div>
-                  Ask Bolt
+                  Ask Rubtle
                 </button>
                 <button
                   onClick={clearAlert}

--- a/app/components/deploy/DeployAlert.tsx
+++ b/app/components/deploy/DeployAlert.tsx
@@ -172,7 +172,7 @@ export default function DeployChatAlert({ alert, clearAlert, postMessage }: Depl
                     )}
                   >
                     <div className="i-ph:chat-circle-duotone"></div>
-                    Ask Bolt
+                    Ask Rubtle
                   </button>
                 )}
                 <button

--- a/app/lib/common/prompts/discuss-prompt.ts
+++ b/app/lib/common/prompts/discuss-prompt.ts
@@ -62,19 +62,19 @@ You are a technical consultant who patiently answers questions and helps the use
 </search_grounding>
 
 <support_resources>
-  When users ask questions about the following topics, you MUST NOT attempt to answer from your own knowledge. Instead, DIRECTLY REDIRECT the user to the official Bolt support resources using a quick action (type "link"):
+  When users ask questions about the following topics, you MUST NOT attempt to answer from your own knowledge. Instead, DIRECTLY REDIRECT the user to the official Rubtle support resources using a quick action (type "link"):
 
   1. Token efficiency: https://support.bolt.new/docs/maximizing-token-efficiency
     - For questions about reducing token usage, optimizing prompts for token economy
 
   2. Effective prompting: https://support.bolt.new/docs/prompting-effectively
-    - For questions about writing better prompts or maximizing prompt effectiveness with Bolt
+    - For questions about writing better prompts or maximizing prompt effectiveness with Rubtle
 
   3. Mobile app development: https://support.bolt.new/docs/how-to-create-mobile-apps
-    - For questions about building/installing Bolt Expo apps on Android/iOS or deploying to web via EAS
+    - For questions about building/installing Rubtle Expo apps on Android/iOS or deploying to web via EAS
 
   5. Supabase: https://support.bolt.new/integrations/supabase
-    - For questions about using Supabase with Bolt, adding databases, storage, or user authentication
+    - For questions about using Supabase with Rubtle, adding databases, storage, or user authentication
     - For questions about edge functions or serverless functions
 
   6. Netlify/Hosting: https://support.bolt.new/integrations/netlify and https://support.bolt.new/faqs/hosting
@@ -163,7 +163,7 @@ You are a technical consultant who patiently answers questions and helps the use
   - Use Vite for web servers
   - ALWAYS choose Node.js scripts over shell scripts
   - Use Supabase for databases by default. If the user specifies otherwise, be aware that only JavaScript-implemented databases/npm packages (e.g., libsql, sqlite) will work
-  - Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
+  - Unless specified by the user, Rubtle ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Rubtle NEVER downloads the images and only links to them in image tags.
 </technology_preferences>
 
 <running_shell_commands_info>

--- a/app/lib/common/prompts/new-prompt.ts
+++ b/app/lib/common/prompts/new-prompt.ts
@@ -10,7 +10,7 @@ export const getFineTunedPrompt = (
     credentials?: { anonKey?: string; supabaseUrl?: string };
   },
 ) => `
-You are Bolt, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices, created by StackBlitz.
+You are Rubtle, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices, created by StackBlitz.
 
 The year is 2025.
 
@@ -41,7 +41,7 @@ The year is 2025.
   - Use Vite for web servers
   - ALWAYS choose Node.js scripts over shell scripts
   - Use Supabase for databases by default. If the user specifies otherwise, be aware that only JavaScript-implemented databases/npm packages (e.g., libsql, sqlite) will work
-  - Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
+  - Unless specified by the user, Rubtle ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Rubtle NEVER downloads the images and only links to them in image tags.
 </technology_preferences>
 
 <running_shell_commands_info>
@@ -50,7 +50,7 @@ The year is 2025.
     - DO NOT repeat or directly quote any part of the command information provided
     - Instead, use this information to inform your understanding of the current system state
     - When referring to running processes, do so naturally as if you inherently know this information
-    - NEVER ask the user to run the commands as these are handled by Bolt.
+    - NEVER ask the user to run the commands as these are handled by Rubtle.
     - For example, if a dev server is running, simply state "The dev server is already running" without explaining how you know this
     - Always maintain the illusion that you have direct knowledge of the system state without relying on explicit command information
 </running_shell_commands_info>
@@ -223,7 +223,7 @@ The year is 2025.
 </database_instructions>
 
 <artifact_instructions>
-  Bolt may create a SINGLE, comprehensive artifact for a response when applicable. If created, the artifact contains all necessary steps and components, including:
+  Rubtle may create a SINGLE, comprehensive artifact for a response when applicable. If created, the artifact contains all necessary steps and components, including:
 
     - Files to create and their contents
     - Shell commands to run including required dependencies
@@ -482,7 +482,7 @@ The year is 2025.
       - Include all possible navigation states (e.g., back, forward, etc.)
 
   8. For photos:
-       - Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
+       - Unless specified by the user, Rubtle ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Rubtle NEVER downloads the images and only links to them in image tags.
 
   EXPO CONFIGURATION:
 

--- a/app/lib/common/prompts/optimized.ts
+++ b/app/lib/common/prompts/optimized.ts
@@ -3,7 +3,7 @@ import type { PromptOptions } from '~/lib/common/prompt-library';
 export default (options: PromptOptions) => {
   const { cwd, allowedHtmlElements, supabase } = options;
   return `
-You are Bolt, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
+You are Rubtle, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
 
 <system_constraints>
   - Operating in WebContainer, an in-browser Node.js runtime

--- a/app/lib/common/prompts/prompts.ts
+++ b/app/lib/common/prompts/prompts.ts
@@ -10,7 +10,7 @@ export const getSystemPrompt = (
     credentials?: { anonKey?: string; supabaseUrl?: string };
   },
 ) => `
-You are Bolt, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
+You are Rubtle, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
 
 <system_constraints>
   You are operating in an environment called WebContainer, an in-browser Node.js runtime that emulates a Linux system to some degree. However, it runs in the browser and doesn't run a full-fledged Linux system and doesn't rely on a cloud VM to execute code. All code is executed in the browser. It does come with a shell that emulates zsh. The container cannot run native binaries since those cannot be executed in the browser. That means it can only execute code that is native to a browser including JS, WebAssembly, etc.
@@ -308,7 +308,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
 </chain_of_thought_instructions>
 
 <artifact_info>
-  Bolt creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
+  Rubtle creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
 
   - Shell commands to run including dependencies to install using a package manager (NPM)
   - Files to create and their contents
@@ -413,7 +413,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
       - Use premium typography with refined hierarchy and spacing.
       - Incorporate microbranding (custom icons, buttons, animations) aligned with the brand voice.
       - Use high-quality, optimized visual assets (photos, illustrations, icons).
-      - IMPORTANT: Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
+      - IMPORTANT: Unless specified by the user, Rubtle ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Rubtle NEVER downloads the images and only links to them in image tags.
 
     Layout & Structure:
       - Implement a systemized spacing/sizing system (e.g., 8pt grid, design tokens).
@@ -511,7 +511,7 @@ ULTRA IMPORTANT: Think first and reply with the artifact that contains all neces
       - Include all possible navigation states (e.g., back, forward, etc.)
 
   8. For photos:
-       - Unless specified by the user, Bolt ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Bolt NEVER downloads the images and only links to them in image tags.
+       - Unless specified by the user, Rubtle ALWAYS uses stock photos from Pexels where appropriate, only valid URLs you know exist. Rubtle NEVER downloads the images and only links to them in image tags.
 
   9. For any React code, start each file with \`import React from 'react';\` to prevent errors.
 

--- a/app/lib/persistence/useChatHistory.ts
+++ b/app/lib/persistence/useChatHistory.ts
@@ -130,7 +130,7 @@ export function useChatHistory() {
                   role: 'assistant',
 
                   // Combine followup message and the artifact with files and command actions
-                  content: `Bolt Restored your chat from a snapshot. You can revert this message to load the full chat history.
+                  content: `Rubtle Restored your chat from a snapshot. You can revert this message to load the full chat history.
                   <boltArtifact id="restored-project-setup" title="Restored Project & Setup" type="bundled">
                   ${Object.entries(snapshot?.files || {})
                     .map(([key, value]) => {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,13 +6,16 @@ import { Header } from '~/components/header/Header';
 import BackgroundRays from '~/components/ui/BackgroundRays';
 
 export const meta: MetaFunction = () => {
-  return [{ title: 'Bolt' }, { name: 'description', content: 'Talk with Bolt, an AI assistant from StackBlitz' }];
+  return [
+    { title: 'Rubtle' },
+    { name: 'description', content: 'Talk with Rubtle, an AI assistant from StackBlitz' },
+  ];
 };
 
 export const loader = () => json({});
 
 /**
- * Landing page component for Bolt
+ * Landing page component for Rubtle
  * Note: Settings functionality should ONLY be accessed through the sidebar menu.
  * Do not add settings button/panel to this landing page as it was intentionally removed
  * to keep the UI clean and consistent with the design system.

--- a/app/routes/api.system.process-info.ts
+++ b/app/routes/api.system.process-info.ts
@@ -343,7 +343,7 @@ const getMockProcessInfo = (): ProcessInfo[] => {
       name: 'bolt',
       cpu: randomHighCPU(),
       memory: 15 + randomMem(),
-      command: 'Bolt AI Process',
+      command: 'Rubtle AI Process',
       timestamp,
     },
     {

--- a/app/routes/git.tsx
+++ b/app/routes/git.tsx
@@ -7,7 +7,10 @@ import { Header } from '~/components/header/Header';
 import BackgroundRays from '~/components/ui/BackgroundRays';
 
 export const meta: MetaFunction = () => {
-  return [{ title: 'Bolt' }, { name: 'description', content: 'Talk with Bolt, an AI assistant from StackBlitz' }];
+  return [
+    { title: 'Rubtle' },
+    { name: 'description', content: 'Talk with Rubtle, an AI assistant from StackBlitz' },
+  ];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/utils/selectStarterTemplate.ts
+++ b/app/utils/selectStarterTemplate.ts
@@ -182,7 +182,7 @@ export async function getTemplates(templateName: string, title?: string) {
   }
 
   const assistantMessage = `
-Bolt is initializing your project with the required files using the ${template.name} template.
+Rubtle is initializing your project with the required files using the ${template.name} template.
 <boltArtifact id="imported-files" title="${title || 'Create initial files'}" type="bundled">
 ${filesToImport.files
   .map(

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.stackblitz.bolt.diy
-productName: Bolt Local
+productName: Rubtle Local
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
## Summary
- update branding in meta tags, prompts, and alerts to mention Rubtle
- rename demo process in API mock
- tweak electron builder product name
- adjust starter template and persisted message text

## Testing
- `pnpm test` *(fails: Request was cancelled due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6849343fa098832b8e6729d501aff5b9