### PR TITLE
Remove update tab configuration

### DIFF
--- a/app/components/@settings/core/ControlPanel.tsx
+++ b/app/components/@settings/core/ControlPanel.tsx
@@ -6,7 +6,6 @@ import * as RadixDialog from '@radix-ui/react-dialog';
 import { classNames } from '~/utils/classNames';
 import { TabManagement } from '~/components/@settings/shared/components/TabManagement';
 import { TabTile } from '~/components/@settings/shared/components/TabTile';
-import { useUpdateCheck } from '~/lib/hooks/useUpdateCheck';
 import { useFeatures } from '~/lib/hooks/useFeatures';
 import { useNotifications } from '~/lib/hooks/useNotifications';
 import { useConnectionStatus } from '~/lib/hooks/useConnectionStatus';
@@ -32,7 +31,6 @@ import FeaturesTab from '~/components/@settings/tabs/features/FeaturesTab';
 import { DataTab } from '~/components/@settings/tabs/data/DataTab';
 import DebugTab from '~/components/@settings/tabs/debug/DebugTab';
 import { EventLogsTab } from '~/components/@settings/tabs/event-logs/EventLogsTab';
-import UpdateTab from '~/components/@settings/tabs/update/UpdateTab';
 import ConnectionsTab from '~/components/@settings/tabs/connections/ConnectionsTab';
 import CloudProvidersTab from '~/components/@settings/tabs/providers/cloud/CloudProvidersTab';
 import ServiceStatusTab from '~/components/@settings/tabs/providers/status/ServiceStatusTab';
@@ -78,13 +76,12 @@ const TAB_DESCRIPTIONS: Record<TabType, string> = {
   connection: 'Check connection status and settings',
   debug: 'Debug tools and system information',
   'event-logs': 'View system events and logs',
-  update: 'Check for updates and release notes',
   'task-manager': 'Monitor system resources and processes',
   'tab-management': 'Configure visible tabs and their order',
 };
 
 // Beta status for experimental features
-const BETA_TABS = new Set<TabType>(['task-manager', 'service-status', 'update', 'local-providers']);
+const BETA_TABS = new Set<TabType>(['task-manager', 'service-status', 'local-providers']);
 
 const BetaLabel = () => (
   <div className="absolute top-2 right-2 px-1.5 py-0.5 rounded-full bg-purple-500/10 dark:bg-purple-500/20">
@@ -164,7 +161,6 @@ export const ControlPanel = ({ open, onClose }: ControlPanelProps) => {
   const profile = useStore(profileStore) as Profile;
 
   // Status hooks
-  const { hasUpdate, currentVersion, acknowledgeUpdate } = useUpdateCheck();
   const { hasNewFeatures, unviewedFeatures, acknowledgeAllFeatures } = useFeatures();
   const { hasUnreadNotifications, unreadNotifications, markAllAsRead } = useNotifications();
   const { hasConnectionIssues, currentIssue, acknowledgeIssue } = useConnectionStatus();
@@ -329,8 +325,6 @@ export const ControlPanel = ({ open, onClose }: ControlPanelProps) => {
         return <DebugTab />;
       case 'event-logs':
         return <EventLogsTab />;
-      case 'update':
-        return <UpdateTab />;
       case 'task-manager':
         return <TaskManagerTab />;
       case 'service-status':
@@ -342,8 +336,6 @@ export const ControlPanel = ({ open, onClose }: ControlPanelProps) => {
 
   const getTabUpdateStatus = (tabId: TabType): boolean => {
     switch (tabId) {
-      case 'update':
-        return hasUpdate;
       case 'features':
         return hasNewFeatures;
       case 'notifications':
@@ -359,8 +351,6 @@ export const ControlPanel = ({ open, onClose }: ControlPanelProps) => {
 
   const getStatusMessage = (tabId: TabType): string => {
     switch (tabId) {
-      case 'update':
-        return `New update available (v${currentVersion})`;
       case 'features':
         return `${unviewedFeatures.length} new feature${unviewedFeatures.length === 1 ? '' : 's'} to explore`;
       case 'notifications':
@@ -389,9 +379,6 @@ export const ControlPanel = ({ open, onClose }: ControlPanelProps) => {
 
     // Acknowledge notifications based on tab
     switch (tabId) {
-      case 'update':
-        acknowledgeUpdate();
-        break;
       case 'features':
         acknowledgeAllFeatures();
         break;

--- a/app/components/@settings/core/constants.ts
+++ b/app/components/@settings/core/constants.ts
@@ -12,7 +12,6 @@ export const TAB_ICONS: Record<TabType, string> = {
   connection: 'i-ph:wifi-high-fill',
   debug: 'i-ph:bug-fill',
   'event-logs': 'i-ph:list-bullets-fill',
-  update: 'i-ph:arrow-clockwise-fill',
   'task-manager': 'i-ph:chart-line-fill',
   'tab-management': 'i-ph:squares-four-fill',
 };
@@ -29,7 +28,6 @@ export const TAB_LABELS: Record<TabType, string> = {
   connection: 'Connection',
   debug: 'Debug',
   'event-logs': 'Event Logs',
-  update: 'Updates',
   'task-manager': 'Task Manager',
   'tab-management': 'Tab Management',
 };
@@ -46,7 +44,6 @@ export const TAB_DESCRIPTIONS: Record<TabType, string> = {
   connection: 'Check connection status and settings',
   debug: 'Debug tools and system information',
   'event-logs': 'View system events and logs',
-  update: 'Check for updates and release notes',
   'task-manager': 'Monitor system resources and processes',
   'tab-management': 'Configure visible tabs and their order',
 };
@@ -69,7 +66,6 @@ export const DEFAULT_TAB_CONFIG = [
 
   // User Window Tabs (Hidden, controlled by TaskManagerTab)
   { id: 'debug', visible: false, window: 'user' as const, order: 11 },
-  { id: 'update', visible: false, window: 'user' as const, order: 12 },
 
   // Developer Window Tabs (All visible by default)
   { id: 'features', visible: true, window: 'developer' as const, order: 0 },
@@ -84,5 +80,4 @@ export const DEFAULT_TAB_CONFIG = [
   { id: 'task-manager', visible: true, window: 'developer' as const, order: 9 },
   { id: 'service-status', visible: true, window: 'developer' as const, order: 10 },
   { id: 'debug', visible: true, window: 'developer' as const, order: 11 },
-  { id: 'update', visible: true, window: 'developer' as const, order: 12 },
 ];

--- a/app/components/@settings/core/types.ts
+++ b/app/components/@settings/core/types.ts
@@ -14,7 +14,6 @@ export type TabType =
   | 'connection'
   | 'debug'
   | 'event-logs'
-  | 'update'
   | 'task-manager'
   | 'tab-management';
 
@@ -78,7 +77,6 @@ export const TAB_LABELS: Record<TabType, string> = {
   connection: 'Connections',
   debug: 'Debug',
   'event-logs': 'Event Logs',
-  update: 'Updates',
   'task-manager': 'Task Manager',
   'tab-management': 'Tab Management',
 };

--- a/app/components/@settings/shared/components/TabManagement.tsx
+++ b/app/components/@settings/shared/components/TabManagement.tsx
@@ -23,7 +23,6 @@ const TAB_ICONS: Record<TabType, string> = {
   connection: 'i-ph:wifi-high-fill',
   debug: 'i-ph:bug-fill',
   'event-logs': 'i-ph:list-bullets-fill',
-  update: 'i-ph:arrow-clockwise-fill',
   'task-manager': 'i-ph:chart-line-fill',
   'tab-management': 'i-ph:squares-four-fill',
 };
@@ -40,13 +39,13 @@ const DEFAULT_USER_TABS: TabType[] = [
 ];
 
 // Define which tabs can be added to user mode
-const OPTIONAL_USER_TABS: TabType[] = ['profile', 'settings', 'task-manager', 'service-status', 'debug', 'update'];
+const OPTIONAL_USER_TABS: TabType[] = ['profile', 'settings', 'task-manager', 'service-status', 'debug'];
 
 // All available tabs for user mode
 const ALL_USER_TABS = [...DEFAULT_USER_TABS, ...OPTIONAL_USER_TABS];
 
 // Define which tabs are beta
-const BETA_TABS = new Set<TabType>(['task-manager', 'service-status', 'update', 'local-providers']);
+const BETA_TABS = new Set<TabType>(['task-manager', 'service-status', 'local-providers']);
 
 // Beta label component
 const BetaLabel = () => (

--- a/app/components/@settings/tabs/task-manager/TaskManagerTab.tsx
+++ b/app/components/@settings/tabs/task-manager/TaskManagerTab.tsx
@@ -14,7 +14,6 @@ import {
   type Chart,
 } from 'chart.js';
 import { toast } from 'react-toastify'; // Import toast
-import { useUpdateCheck } from '~/lib/hooks/useUpdateCheck';
 import { tabConfigurationStore, type TabConfig } from '~/lib/stores/tabConfigurationStore';
 import { useStore } from 'zustand';
 
@@ -294,8 +293,7 @@ const TaskManagerTab: React.FC = () => {
     return cleanupCharts;
   }, []);
 
-  // Get update status and tab configuration
-  const { hasUpdate } = useUpdateCheck();
+  // Get tab configuration
   const tabConfig = useStore(tabConfigurationStore);
 
   const resetTabConfiguration = useCallback(() => {
@@ -307,14 +305,14 @@ const TaskManagerTab: React.FC = () => {
   useEffect(() => {
     const handleTabVisibility = () => {
       const currentConfig = tabConfig.get();
-      const controlledTabs = ['debug', 'update'];
+      const controlledTabs = ['debug'];
 
       // Update visibility based on conditions
       const updatedTabs = currentConfig.userTabs.map((tab: TabConfig) => {
         if (controlledTabs.includes(tab.id)) {
           return {
             ...tab,
-            visible: tab.id === 'debug' ? metrics.memory.percentage > 80 : hasUpdate,
+            visible: metrics.memory.percentage > 80,
           };
         }
 
@@ -332,7 +330,7 @@ const TaskManagerTab: React.FC = () => {
     return () => {
       clearInterval(checkInterval);
     };
-  }, [metrics.memory.percentage, hasUpdate, tabConfig]);
+  }, [metrics.memory.percentage, tabConfig]);
 
   // Effect to handle reset and initialization
   useEffect(() => {

--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -25,6 +25,14 @@ export function Header() {
           {/* <span className="i-bolt:logo-text?mask w-[46px] inline-block" /> */}
           <img src="/RUBTLELOGO.svg" alt="logo" className="w-[90px]" />
         </a>
+        <a
+          href="https://rubtle.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm ml-2 hover:text-purple-500"
+        >
+          Rubtle.com
+        </a>
       </div>
       {chat.started && ( // Display ChatDescription and HeaderActionButtons only when the chat has started.
         <>


### PR DESCRIPTION
## Summary
- drop update tab from settings constants and types
- strip update tab logic from settings control panel and tab management
- simplify task manager tab update check logic
- add link to Rubtle.com in header

## Testing
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68493669dd68832b89c3be46c31740e7