### PR TITLE
Remove update and service status tabs

### DIFF
--- a/app/components/@settings/core/AvatarDropdown.tsx
+++ b/app/components/@settings/core/AvatarDropdown.tsx
@@ -135,22 +135,6 @@ export const AvatarDropdown = ({ onSelectTab }: AvatarDropdownProps) => {
             <BetaLabel />
           </DropdownMenu.Item>
 
-          <DropdownMenu.Item
-            className={classNames(
-              'flex items-center gap-2 px-4 py-2.5',
-              'text-sm text-gray-700 dark:text-gray-200',
-              'hover:bg-purple-50 dark:hover:bg-purple-500/10',
-              'hover:text-purple-500 dark:hover:text-purple-400',
-              'cursor-pointer transition-all duration-200',
-              'outline-none',
-              'group',
-            )}
-            onClick={() => onSelectTab('service-status')}
-          >
-            <div className="i-ph:heartbeat w-4 h-4 text-gray-400 group-hover:text-purple-500 dark:group-hover:text-purple-400 transition-colors" />
-            Service Status
-            <BetaLabel />
-          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/app/components/@settings/core/constants.ts
+++ b/app/components/@settings/core/constants.ts
@@ -8,11 +8,9 @@ export const TAB_ICONS: Record<TabType, string> = {
   data: 'i-ph:database-fill',
   'cloud-providers': 'i-ph:cloud-fill',
   'local-providers': 'i-ph:desktop-fill',
-  'service-status': 'i-ph:activity-bold',
   connection: 'i-ph:wifi-high-fill',
   debug: 'i-ph:bug-fill',
   'event-logs': 'i-ph:list-bullets-fill',
-  update: 'i-ph:arrow-clockwise-fill',
   'task-manager': 'i-ph:chart-line-fill',
   'tab-management': 'i-ph:squares-four-fill',
 };
@@ -25,11 +23,9 @@ export const TAB_LABELS: Record<TabType, string> = {
   data: 'Data Management',
   'cloud-providers': 'Cloud Providers',
   'local-providers': 'Local Providers',
-  'service-status': 'Service Status',
   connection: 'Connection',
   debug: 'Debug',
   'event-logs': 'Event Logs',
-  update: 'Updates',
   'task-manager': 'Task Manager',
   'tab-management': 'Tab Management',
 };
@@ -42,11 +38,9 @@ export const TAB_DESCRIPTIONS: Record<TabType, string> = {
   data: 'Manage your data and storage',
   'cloud-providers': 'Configure cloud AI providers and models',
   'local-providers': 'Configure local AI providers and models',
-  'service-status': 'Monitor cloud LLM service status',
   connection: 'Check connection status and settings',
   debug: 'Debug tools and system information',
   'event-logs': 'View system events and logs',
-  update: 'Check for updates and release notes',
   'task-manager': 'Monitor system resources and processes',
   'tab-management': 'Configure visible tabs and their order',
 };
@@ -65,11 +59,9 @@ export const DEFAULT_TAB_CONFIG = [
   { id: 'profile', visible: false, window: 'user' as const, order: 7 },
   { id: 'settings', visible: false, window: 'user' as const, order: 8 },
   { id: 'task-manager', visible: false, window: 'user' as const, order: 9 },
-  { id: 'service-status', visible: false, window: 'user' as const, order: 10 },
 
   // User Window Tabs (Hidden, controlled by TaskManagerTab)
-  { id: 'debug', visible: false, window: 'user' as const, order: 11 },
-  { id: 'update', visible: false, window: 'user' as const, order: 12 },
+  { id: 'debug', visible: false, window: 'user' as const, order: 10 },
 
   // Developer Window Tabs (All visible by default)
   { id: 'features', visible: true, window: 'developer' as const, order: 0 },
@@ -82,7 +74,5 @@ export const DEFAULT_TAB_CONFIG = [
   { id: 'profile', visible: true, window: 'developer' as const, order: 7 },
   { id: 'settings', visible: true, window: 'developer' as const, order: 8 },
   { id: 'task-manager', visible: true, window: 'developer' as const, order: 9 },
-  { id: 'service-status', visible: true, window: 'developer' as const, order: 10 },
-  { id: 'debug', visible: true, window: 'developer' as const, order: 11 },
-  { id: 'update', visible: true, window: 'developer' as const, order: 12 },
+  { id: 'debug', visible: true, window: 'developer' as const, order: 10 },
 ];

--- a/app/components/@settings/core/types.ts
+++ b/app/components/@settings/core/types.ts
@@ -10,11 +10,9 @@ export type TabType =
   | 'data'
   | 'cloud-providers'
   | 'local-providers'
-  | 'service-status'
   | 'connection'
   | 'debug'
   | 'event-logs'
-  | 'update'
   | 'task-manager'
   | 'tab-management';
 
@@ -74,11 +72,9 @@ export const TAB_LABELS: Record<TabType, string> = {
   data: 'Data Management',
   'cloud-providers': 'Cloud Providers',
   'local-providers': 'Local Providers',
-  'service-status': 'Service Status',
   connection: 'Connections',
   debug: 'Debug',
   'event-logs': 'Event Logs',
-  update: 'Updates',
   'task-manager': 'Task Manager',
   'tab-management': 'Tab Management',
 };

--- a/app/components/@settings/shared/components/TabManagement.tsx
+++ b/app/components/@settings/shared/components/TabManagement.tsx
@@ -19,11 +19,9 @@ const TAB_ICONS: Record<TabType, string> = {
   data: 'i-ph:database-fill',
   'cloud-providers': 'i-ph:cloud-fill',
   'local-providers': 'i-ph:desktop-fill',
-  'service-status': 'i-ph:activity-fill',
   connection: 'i-ph:wifi-high-fill',
   debug: 'i-ph:bug-fill',
   'event-logs': 'i-ph:list-bullets-fill',
-  update: 'i-ph:arrow-clockwise-fill',
   'task-manager': 'i-ph:chart-line-fill',
   'tab-management': 'i-ph:squares-four-fill',
 };
@@ -40,13 +38,13 @@ const DEFAULT_USER_TABS: TabType[] = [
 ];
 
 // Define which tabs can be added to user mode
-const OPTIONAL_USER_TABS: TabType[] = ['profile', 'settings', 'task-manager', 'service-status', 'debug', 'update'];
+const OPTIONAL_USER_TABS: TabType[] = ['profile', 'settings', 'task-manager', 'debug'];
 
 // All available tabs for user mode
 const ALL_USER_TABS = [...DEFAULT_USER_TABS, ...OPTIONAL_USER_TABS];
 
 // Define which tabs are beta
-const BETA_TABS = new Set<TabType>(['task-manager', 'service-status', 'update', 'local-providers']);
+const BETA_TABS = new Set<TabType>(['task-manager']);
 
 // Beta label component
 const BetaLabel = () => (

--- a/app/components/@settings/shared/components/TabTile.tsx
+++ b/app/components/@settings/shared/components/TabTile.tsx
@@ -1,5 +1,4 @@
 import { motion } from 'framer-motion';
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { classNames } from '~/utils/classNames';
 import type { TabVisibilityConfig } from '~/components/@settings/core/types';
 import { TAB_LABELS, TAB_ICONS } from '~/components/@settings/core/constants';
@@ -8,8 +7,6 @@ interface TabTileProps {
   tab: TabVisibilityConfig;
   onClick?: () => void;
   isActive?: boolean;
-  hasUpdate?: boolean;
-  statusMessage?: string;
   description?: string;
   isLoading?: boolean;
   className?: string;
@@ -20,116 +17,72 @@ export const TabTile: React.FC<TabTileProps> = ({
   tab,
   onClick,
   isActive,
-  hasUpdate,
-  statusMessage,
   description,
   isLoading,
   className,
   children,
 }: TabTileProps) => {
   return (
-    <Tooltip.Provider delayDuration={200}>
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <motion.div
-            onClick={onClick}
+    <motion.div
+      onClick={onClick}
+      className={classNames(
+        'relative flex items-center gap-4 p-4 rounded-lg',
+        'w-full',
+        'bg-white dark:bg-[#141414]',
+        'border border-[#E5E5E5] dark:border-[#333333]',
+        'group',
+        'hover:bg-purple-50 dark:hover:bg-[#1a1a1a]',
+        'hover:border-purple-200 dark:hover:border-purple-900/30',
+        isActive ? 'border-purple-500 dark:border-purple-500/50 bg-purple-500/5 dark:bg-purple-500/10' : '',
+        isLoading ? 'cursor-wait opacity-70' : '',
+        className || ''
+      )}
+    >
+      <motion.div
+        className={classNames(
+          'relative w-10 h-10 flex items-center justify-center rounded-lg',
+          'bg-gray-100 dark:bg-gray-900',
+          'ring-1 ring-gray-200 dark:ring-gray-700',
+          'group-hover:bg-purple-100 dark:group-hover:bg-gray-700/80',
+          'group-hover:ring-purple-200 dark:group-hover:ring-purple-800/30',
+          isActive ? 'bg-purple-500/10 dark:bg-purple-500/10 ring-purple-500/30 dark:ring-purple-500/20' : ''
+        )}
+      >
+        <motion.div
+          className={classNames(
+            TAB_ICONS[tab.id],
+            'w-6 h-6',
+            'text-gray-600 dark:text-gray-300',
+            'group-hover:text-purple-500 dark:group-hover:text-purple-400/80',
+            isActive ? 'text-purple-500 dark:text-purple-400/90' : ''
+          )}
+        />
+      </motion.div>
+      <div className="flex flex-col ml-4">
+        <h3
+          className={classNames(
+            'text-sm font-medium',
+            'text-gray-700 dark:text-gray-200',
+            'group-hover:text-purple-600 dark:group-hover:text-purple-300/90',
+            isActive ? 'text-purple-500 dark:text-purple-400/90' : ''
+          )}
+        >
+          {TAB_LABELS[tab.id]}
+        </h3>
+        {description && (
+          <p
             className={classNames(
-              'relative flex flex-col items-center p-6 rounded-xl',
-              'w-full h-full min-h-[160px]',
-              'bg-white dark:bg-[#141414]',
-              'border border-[#E5E5E5] dark:border-[#333333]',
-              'group',
-              'hover:bg-purple-50 dark:hover:bg-[#1a1a1a]',
-              'hover:border-purple-200 dark:hover:border-purple-900/30',
-              isActive ? 'border-purple-500 dark:border-purple-500/50 bg-purple-500/5 dark:bg-purple-500/10' : '',
-              isLoading ? 'cursor-wait opacity-70' : '',
-              className || '',
+              'text-xs',
+              'text-gray-500 dark:text-gray-400',
+              'group-hover:text-purple-500 dark:group-hover:text-purple-400/70',
+              isActive ? 'text-purple-400 dark:text-purple-400/80' : ''
             )}
           >
-            {/* Main Content */}
-            <div className="flex flex-col items-center justify-center flex-1 w-full">
-              {/* Icon */}
-              <motion.div
-                className={classNames(
-                  'relative',
-                  'w-14 h-14',
-                  'flex items-center justify-center',
-                  'rounded-xl',
-                  'bg-gray-100 dark:bg-gray-900',
-                  'ring-1 ring-gray-200 dark:ring-gray-700',
-                  'group-hover:bg-purple-100 dark:group-hover:bg-gray-700/80',
-                  'group-hover:ring-purple-200 dark:group-hover:ring-purple-800/30',
-                  isActive ? 'bg-purple-500/10 dark:bg-purple-500/10 ring-purple-500/30 dark:ring-purple-500/20' : '',
-                )}
-              >
-                <motion.div
-                  className={classNames(
-                    TAB_ICONS[tab.id],
-                    'w-8 h-8',
-                    'text-gray-600 dark:text-gray-300',
-                    'group-hover:text-purple-500 dark:group-hover:text-purple-400/80',
-                    isActive ? 'text-purple-500 dark:text-purple-400/90' : '',
-                  )}
-                />
-              </motion.div>
-
-              {/* Label and Description */}
-              <div className="flex flex-col items-center mt-5 w-full">
-                <h3
-                  className={classNames(
-                    'text-[15px] font-medium leading-snug mb-2',
-                    'text-gray-700 dark:text-gray-200',
-                    'group-hover:text-purple-600 dark:group-hover:text-purple-300/90',
-                    isActive ? 'text-purple-500 dark:text-purple-400/90' : '',
-                  )}
-                >
-                  {TAB_LABELS[tab.id]}
-                </h3>
-                {description && (
-                  <p
-                    className={classNames(
-                      'text-[13px] leading-relaxed',
-                      'text-gray-500 dark:text-gray-400',
-                      'max-w-[85%]',
-                      'text-center',
-                      'group-hover:text-purple-500 dark:group-hover:text-purple-400/70',
-                      isActive ? 'text-purple-400 dark:text-purple-400/80' : '',
-                    )}
-                  >
-                    {description}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            {/* Update Indicator with Tooltip */}
-            {hasUpdate && (
-              <>
-                <div className="absolute top-4 right-4 w-2 h-2 rounded-full bg-purple-500 dark:bg-purple-400 animate-pulse" />
-                <Tooltip.Portal>
-                  <Tooltip.Content
-                    className={classNames(
-                      'px-3 py-1.5 rounded-lg',
-                      'bg-[#18181B] text-white',
-                      'text-sm font-medium',
-                      'select-none',
-                      'z-[100]',
-                    )}
-                    side="top"
-                    sideOffset={5}
-                  >
-                    {statusMessage}
-                    <Tooltip.Arrow className="fill-[#18181B]" />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              </>
-            )}
-
-            {/* Children (e.g. Beta Label) */}
-            {children}
-          </motion.div>
-        </Tooltip.Trigger>
-      </Tooltip.Root>
-    </Tooltip.Provider>
+            {description}
+          </p>
+        )}
+      </div>
+      {children}
+    </motion.div>
   );
 };


### PR DESCRIPTION
## Summary
- drop `update` and `service-status` tabs
- strip BETA label from local providers
- simplify avatar menu
- update TabTile into a list style
- remove update status handling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493b7fdb20832bbb05b84f6cd5e607