### PR TITLE
Remove beta label and prompt text

### DIFF
--- a/app/components/@settings/core/AvatarDropdown.tsx
+++ b/app/components/@settings/core/AvatarDropdown.tsx
@@ -5,12 +5,6 @@ import { classNames } from '~/utils/classNames';
 import { profileStore } from '~/lib/stores/profile';
 import type { TabType, Profile } from './types';
 
-const BetaLabel = () => (
-  <span className="px-1.5 py-0.5 rounded-full bg-purple-500/10 dark:bg-purple-500/20 text-[10px] font-medium text-purple-600 dark:text-purple-400 ml-2">
-    BETA
-  </span>
-);
-
 interface AvatarDropdownProps {
   onSelectTab: (tab: TabType) => void;
 }
@@ -132,7 +126,6 @@ export const AvatarDropdown = ({ onSelectTab }: AvatarDropdownProps) => {
           >
             <div className="i-ph:activity w-4 h-4 text-gray-400 group-hover:text-purple-500 dark:group-hover:text-purple-400 transition-colors" />
             Task Manager
-            <BetaLabel />
           </DropdownMenu.Item>
 
         </DropdownMenu.Content>

--- a/app/components/@settings/core/ControlPanel.tsx
+++ b/app/components/@settings/core/ControlPanel.tsx
@@ -79,7 +79,7 @@ const TAB_DESCRIPTIONS: Record<TabType, string> = {
 };
 
 // Beta status for experimental features
-const BETA_TABS = new Set<TabType>(['task-manager']);
+const BETA_TABS = new Set<TabType>();
 
 const BetaLabel = () => (
   <div className="absolute top-2 right-2 px-1.5 py-0.5 rounded-full bg-purple-500/10 dark:bg-purple-500/20">

--- a/app/components/@settings/shared/components/TabManagement.tsx
+++ b/app/components/@settings/shared/components/TabManagement.tsx
@@ -44,7 +44,7 @@ const OPTIONAL_USER_TABS: TabType[] = ['profile', 'settings', 'task-manager', 'd
 const ALL_USER_TABS = [...DEFAULT_USER_TABS, ...OPTIONAL_USER_TABS];
 
 // Define which tabs are beta
-const BETA_TABS = new Set<TabType>(['task-manager']);
+const BETA_TABS = new Set<TabType>();
 
 // Beta label component
 const BetaLabel = () => (

--- a/app/components/@settings/tabs/features/FeaturesTab.tsx
+++ b/app/components/@settings/tabs/features/FeaturesTab.tsx
@@ -263,9 +263,6 @@ export default function FeaturesTab() {
             <h4 className="text-sm font-medium text-bolt-elements-textPrimary group-hover:text-purple-500 transition-colors">
               Prompt Library
             </h4>
-            <p className="text-xs text-bolt-elements-textSecondary mt-0.5">
-              Choose a prompt from the library to use as the system prompt
-            </p>
           </div>
           <select
             value={promptId}


### PR DESCRIPTION
## Summary
- remove help text from the Prompt Library entry in Features settings
- drop Beta labels from Task Manager UI

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68493f96c668832bbde10c4623b3ab55