### PR TITLE
Adjust npm install and add Force Install

### DIFF
--- a/app/components/workbench/terminal/TerminalTabs.tsx
+++ b/app/components/workbench/terminal/TerminalTabs.tsx
@@ -32,6 +32,10 @@ export const TerminalTabs = memo(() => {
     }
   };
 
+  const handleForceInstall = () => {
+    workbenchStore.forceInstall();
+  };
+
   useEffect(() => {
     const { current: terminal } = terminalPanelRef;
 
@@ -131,7 +135,15 @@ export const TerminalTabs = memo(() => {
                 </React.Fragment>
               );
             })}
-            {terminalCount < MAX_TERMINALS && <IconButton icon="i-ph:plus" size="md" onClick={addTerminal} />}
+            {terminalCount < MAX_TERMINALS && (
+              <IconButton icon="i-ph:plus" size="md" onClick={addTerminal} />
+            )}
+            <IconButton
+              icon="i-ph:package"
+              title="Force Install"
+              size="md"
+              onClick={handleForceInstall}
+            />
             <IconButton
               className="ml-auto"
               icon="i-ph:caret-down"

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -140,6 +140,16 @@ export class WorkbenchStore {
     this.#terminalStore.toggleTerminal(value);
   }
 
+  async forceInstall() {
+    this.toggleTerminal(true);
+    const shell = this.boltTerminal;
+    await shell.ready();
+    await shell.executeCommand(
+      `force-install-${Date.now()}`,
+      'npm install --legacy-peer-deps',
+    );
+  }
+
   attachTerminal(terminal: ITerminal) {
     this.#terminalStore.attachTerminal(terminal);
   }


### PR DESCRIPTION
## Summary
- revert project setup to use `npm install`
- expose `forceInstall` command in workbench store
- show **Force Install** button next to the terminal

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684a6232008c832b82cf5fd3f6adb417