### PR TITLE
Hide model selector by default

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -121,7 +121,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
     const TEXTAREA_MAX_HEIGHT = chatStarted ? 400 : 200;
     const [apiKeys, setApiKeys] = useState<Record<string, string>>(getApiKeysFromCookies());
     const [modelList, setModelList] = useState<ModelInfo[]>([]);
-    const [isModelSettingsCollapsed, setIsModelSettingsCollapsed] = useState(false);
+    // Hide model selector and API key fields by default
+    const [isModelSettingsCollapsed, setIsModelSettingsCollapsed] = useState(true);
     const [isListening, setIsListening] = useState(false);
     const [recognition, setRecognition] = useState<SpeechRecognition | null>(null);
     const [transcript, setTranscript] = useState('');


### PR DESCRIPTION
## Summary
- collapse model and API key section by default so they show only when clicking the toggle button

## Testing
- `pnpm test` *(fails: fetch to npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684aeaa75fc8832bb34a8bdc11a32717