### PR TITLE
Add custom prompt rules in settings

### DIFF
--- a/app/components/@settings/tabs/settings/SettingsTab.tsx
+++ b/app/components/@settings/tabs/settings/SettingsTab.tsx
@@ -5,6 +5,7 @@ import { classNames } from '~/utils/classNames';
 import { Switch } from '~/components/ui/Switch';
 import type { UserProfile } from '~/components/@settings/core/types';
 import { isMac } from '~/utils/os';
+import { useSettings } from '~/lib/hooks/useSettings';
 
 // Helper to get modifier key symbols/text
 const getModifierSymbol = (modifier: string): string => {
@@ -33,9 +34,16 @@ export default function SettingsTab() {
         };
   });
 
+  const { promptRules, setPromptRules } = useSettings();
+  const [rules, setRules] = useState<string>(() => promptRules);
+
   useEffect(() => {
     setCurrentTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);
   }, []);
+
+  useEffect(() => {
+    setPromptRules(rules);
+  }, [rules, setPromptRules]);
 
   // Save settings automatically when they change
   useEffect(() => {
@@ -209,6 +217,36 @@ export default function SettingsTab() {
             </div>
           </div>
         </div>
+      </motion.div>
+
+      {/* Prompt Rules */}
+      <motion.div
+        className="bg-white dark:bg-[#0A0A0A] rounded-lg shadow-sm dark:shadow-none p-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.4 }}
+      >
+        <div className="flex items-center gap-2 mb-4">
+          <div className="i-ph:list-plus-fill w-4 h-4 text-purple-500" />
+          <span className="text-sm font-medium text-bolt-elements-textPrimary">Rules</span>
+        </div>
+        <textarea
+          value={rules}
+          onChange={(e) => setRules(e.target.value)}
+          className={classNames(
+            'w-full p-2 rounded-lg text-sm',
+            'bg-[#FAFAFA] dark:bg-[#0A0A0A]',
+            'border border-[#E5E5E5] dark:border-[#1A1A1A]',
+            'text-bolt-elements-textPrimary',
+            'focus:outline-none focus:ring-2 focus:ring-purple-500/30',
+            'transition-all duration-200',
+          )}
+          rows={4}
+          placeholder="Add additional prompt rules here"
+        />
+        <p className="text-xs text-bolt-elements-textSecondary mt-2">
+          These rules will be appended to the system prompt.
+        </p>
       </motion.div>
     </div>
   );

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -38,6 +38,7 @@ export async function streamText(props: {
   summary?: string;
   messageSliceId?: number;
   chatMode?: 'discuss' | 'build';
+  promptRules?: string;
 }) {
   const {
     messages,
@@ -51,6 +52,7 @@ export async function streamText(props: {
     contextFiles,
     summary,
     chatMode,
+    promptRules,
   } = props;
   let currentModel = DEFAULT_MODEL;
   let currentProvider = DEFAULT_PROVIDER.name;
@@ -126,6 +128,10 @@ export async function streamText(props: {
         credentials: options?.supabaseConnection?.credentials || undefined,
       },
     }) ?? getSystemPrompt();
+
+  if (promptRules) {
+    systemPrompt = `${systemPrompt}\n${promptRules}`;
+  }
 
   if (chatMode === 'build' && contextFiles && contextOptimization) {
     const codeContext = createFilesContext(contextFiles, true);

--- a/app/lib/api/cookies.ts
+++ b/app/lib/api/cookies.ts
@@ -31,3 +31,8 @@ export function getProviderSettingsFromCookie(cookieHeader: string | null): Reco
   const cookies = parseCookies(cookieHeader);
   return cookies.providers ? JSON.parse(cookies.providers) : {};
 }
+
+export function getPromptRulesFromCookie(cookieHeader: string | null): string {
+  const cookies = parseCookies(cookieHeader);
+  return cookies.promptRules ? cookies.promptRules : '';
+}

--- a/app/lib/hooks/useSettings.ts
+++ b/app/lib/hooks/useSettings.ts
@@ -3,6 +3,7 @@ import {
   isDebugMode,
   isEventLogsEnabled,
   promptStore,
+  promptRulesStore,
   providersStore,
   latestBranchStore,
   autoSelectStarterTemplate,
@@ -16,6 +17,7 @@ import {
   updateContextOptimization,
   updateEventLogs,
   updatePromptId,
+  updatePromptRules,
 } from '~/lib/stores/settings';
 import { useCallback, useEffect, useState } from 'react';
 import Cookies from 'js-cookie';
@@ -31,6 +33,7 @@ export interface Settings {
   eventLogs: boolean;
   timezone: string;
   tabConfiguration: TabWindowConfig;
+  promptRules: string;
 }
 
 export interface UseSettingsReturn {
@@ -40,6 +43,7 @@ export interface UseSettingsReturn {
   setNotifications: (enabled: boolean) => void;
   setEventLogs: (enabled: boolean) => void;
   setTimezone: (timezone: string) => void;
+  setPromptRules: (rules: string) => void;
   settings: Settings;
 
   // Provider settings
@@ -53,6 +57,7 @@ export interface UseSettingsReturn {
   eventLogs: boolean;
   promptId: string;
   setPromptId: (promptId: string) => void;
+  promptRules: string;
   isLatestBranch: boolean;
   enableLatestBranch: (enabled: boolean) => void;
   autoSelectTemplate: boolean;
@@ -76,6 +81,7 @@ export function useSettings(): UseSettingsReturn {
   const debug = useStore(isDebugMode);
   const eventLogs = useStore(isEventLogsEnabled);
   const promptId = useStore(promptStore);
+  const promptRules = useStore(promptRulesStore);
   const isLatestBranch = useStore(latestBranchStore);
   const autoSelectTemplate = useStore(autoSelectStarterTemplate);
   const [activeProviders, setActiveProviders] = useState<ProviderInfo[]>([]);
@@ -90,6 +96,7 @@ export function useSettings(): UseSettingsReturn {
       eventLogs: storedSettings?.eventLogs ?? true,
       timezone: storedSettings?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
       tabConfiguration,
+      promptRules: storedSettings?.promptRules || '',
     };
   });
 
@@ -129,6 +136,12 @@ export function useSettings(): UseSettingsReturn {
     updatePromptId(id);
     logStore.logSystem(`Prompt template updated to ${id}`);
   }, []);
+
+  const setPromptRules = useCallback((rules: string) => {
+    updatePromptRules(rules);
+    logStore.logSystem('Prompt rules updated');
+    saveSettings({ promptRules: rules });
+  }, [saveSettings]);
 
   const enableLatestBranch = useCallback((enabled: boolean) => {
     updateLatestBranch(enabled);
@@ -193,6 +206,8 @@ export function useSettings(): UseSettingsReturn {
     setEventLogs,
     promptId,
     setPromptId,
+    promptRules,
+    setPromptRules,
     isLatestBranch,
     enableLatestBranch,
     autoSelectTemplate,

--- a/app/lib/services/importExportService.ts
+++ b/app/lib/services/importExportService.ts
@@ -123,6 +123,7 @@ export class ImportExportService {
           // Prompt settings
           promptId: this._safeGetItem('promptId'),
           cachedPrompt: allCookies.cachedPrompt,
+          promptRules: allCookies.promptRules,
         },
 
         // Connections
@@ -436,7 +437,7 @@ export class ImportExportService {
       }
 
       // Import UI cookies
-      const uiCookies = ['tabConfiguration', 'cachedPrompt'];
+      const uiCookies = ['tabConfiguration', 'cachedPrompt', 'promptRules'];
       uiCookies.forEach((key) => {
         if (data.ui[key]) {
           try {
@@ -564,6 +565,7 @@ export class ImportExportService {
             'providers',
             'tabConfiguration',
             'cachedPrompt',
+            'promptRules',
             'isDebugEnabled',
             'eventLogs',
           ].includes(key);

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -120,6 +120,7 @@ const SETTINGS_KEYS = {
   EVENT_LOGS: 'isEventLogsEnabled',
   PROMPT_ID: 'promptId',
   DEVELOPER_MODE: 'isDeveloperMode',
+  PROMPT_RULES: 'promptRules',
 } as const;
 
 // Initialize settings from localStorage or defaults
@@ -148,6 +149,7 @@ const getInitialSettings = () => {
     contextOptimization: getStoredBoolean(SETTINGS_KEYS.CONTEXT_OPTIMIZATION, true),
     eventLogs: getStoredBoolean(SETTINGS_KEYS.EVENT_LOGS, true),
     promptId: isBrowser ? localStorage.getItem(SETTINGS_KEYS.PROMPT_ID) || 'default' : 'default',
+    promptRules: isBrowser ? localStorage.getItem(SETTINGS_KEYS.PROMPT_RULES) || '' : '',
     developerMode: getStoredBoolean(SETTINGS_KEYS.DEVELOPER_MODE, false),
   };
 };
@@ -160,6 +162,7 @@ export const autoSelectStarterTemplate = atom<boolean>(initialSettings.autoSelec
 export const enableContextOptimizationStore = atom<boolean>(initialSettings.contextOptimization);
 export const isEventLogsEnabled = atom<boolean>(initialSettings.eventLogs);
 export const promptStore = atom<string>(initialSettings.promptId);
+export const promptRulesStore = atom<string>(initialSettings.promptRules);
 
 // Helper functions to update settings with persistence
 export const updateLatestBranch = (enabled: boolean) => {
@@ -185,6 +188,12 @@ export const updateEventLogs = (enabled: boolean) => {
 export const updatePromptId = (id: string) => {
   promptStore.set(id);
   localStorage.setItem(SETTINGS_KEYS.PROMPT_ID, id);
+};
+
+export const updatePromptRules = (rules: string) => {
+  promptRulesStore.set(rules);
+  localStorage.setItem(SETTINGS_KEYS.PROMPT_RULES, rules);
+  Cookies.set('promptRules', rules);
 };
 
 // Initialize tab configuration from localStorage or defaults

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -58,6 +58,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
   const providerSettings: Record<string, IProviderSetting> = JSON.parse(
     parseCookies(cookieHeader || '').providers || '{}',
   );
+  const promptRules = parseCookies(cookieHeader || '').promptRules || '';
 
   const stream = new SwitchableStream();
 
@@ -252,6 +253,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               chatMode,
               summary,
               messageSliceId,
+              promptRules,
             });
 
             result.mergeIntoDataStream(dataStream);
@@ -292,6 +294,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
           chatMode,
           summary,
           messageSliceId,
+          promptRules,
         });
 
         (async () => {

--- a/app/routes/api.enhancer.ts
+++ b/app/routes/api.enhancer.ts
@@ -2,7 +2,7 @@ import { type ActionFunctionArgs } from '@remix-run/cloudflare';
 import { streamText } from '~/lib/.server/llm/stream-text';
 import { stripIndents } from '~/utils/stripIndent';
 import type { ProviderInfo } from '~/types/model';
-import { getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
+import { parseCookies, getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
 import { createScopedLogger } from '~/utils/logger';
 
 export async function action(args: ActionFunctionArgs) {
@@ -39,6 +39,7 @@ async function enhancerAction({ context, request }: ActionFunctionArgs) {
   const cookieHeader = request.headers.get('Cookie');
   const apiKeys = getApiKeysFromCookie(cookieHeader);
   const providerSettings = getProviderSettingsFromCookie(cookieHeader);
+  const promptRules = cookieHeader ? parseCookies(cookieHeader).promptRules || '' : '';
 
   try {
     const result = await streamText({
@@ -80,6 +81,7 @@ async function enhancerAction({ context, request }: ActionFunctionArgs) {
       env: context.cloudflare?.env as any,
       apiKeys,
       providerSettings,
+      promptRules,
       options: {
         system:
           'You are a senior software principal architect, you should help the user analyse the user query and enrich it with the necessary context and constraints to make it more specific, actionable, and effective. You should also ensure that the prompt is self-contained and uses professional language. Your response should ONLY contain the enhanced prompt text. Do not include any explanations, metadata, or wrapper tags.',

--- a/app/routes/api.llmcall.ts
+++ b/app/routes/api.llmcall.ts
@@ -6,7 +6,7 @@ import { PROVIDER_LIST } from '~/utils/constants';
 import { MAX_TOKENS } from '~/lib/.server/llm/constants';
 import { LLMManager } from '~/lib/modules/llm/manager';
 import type { ModelInfo } from '~/lib/modules/llm/types';
-import { getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
+import { parseCookies, getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
 import { createScopedLogger } from '~/utils/logger';
 
 export async function action(args: ActionFunctionArgs) {
@@ -53,6 +53,7 @@ async function llmCallAction({ context, request }: ActionFunctionArgs) {
   const cookieHeader = request.headers.get('Cookie');
   const apiKeys = getApiKeysFromCookie(cookieHeader);
   const providerSettings = getProviderSettingsFromCookie(cookieHeader);
+  const promptRules = cookieHeader ? parseCookies(cookieHeader).promptRules || '' : '';
 
   if (streamOutput) {
     try {
@@ -69,6 +70,7 @@ async function llmCallAction({ context, request }: ActionFunctionArgs) {
         env: context.cloudflare?.env as any,
         apiKeys,
         providerSettings,
+        promptRules,
       });
 
       return new Response(result.textStream, {


### PR DESCRIPTION
## Summary
- allow user-defined prompt rules appended to system prompt
- persist rules in settings store
- expose promptRules in API calls and server logic
- export/import promptRules in settings
- add Rules textarea in settings UI

## Testing
- `pnpm lint` *(fails: network access required)*
- `pnpm test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_684c89bbb09c832b81e6ae2599176bac