### PR TITLE
Allow adding custom rules

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -74,6 +74,8 @@ interface BaseChatProps {
   chatMode?: 'discuss' | 'build';
   setChatMode?: (mode: 'discuss' | 'build') => void;
   append?: (message: Message) => void;
+  rules?: string;
+  setRules?: (rules: string) => void;
 }
 
 export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
@@ -115,6 +117,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       chatMode,
       setChatMode,
       append,
+      rules,
+      setRules,
     },
     ref,
   ) => {
@@ -454,6 +458,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   handleFileUpload={handleFileUpload}
                   chatMode={chatMode}
                   setChatMode={setChatMode}
+                  rules={rules}
+                  setRules={setRules}
                 />
               </div>
             </StickToBottom>

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -27,6 +27,7 @@ import { logStore } from '~/lib/stores/logs';
 import { streamingState } from '~/lib/stores/streaming';
 import { filesToArtifacts } from '~/utils/fileUtils';
 import { supabaseConnection } from '~/lib/stores/supabase';
+import { useUserRules } from '~/lib/hooks/useUserRules';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -130,8 +131,9 @@ export const ChatImpl = memo(
     const selectedProject = supabaseConn.stats?.projects?.find(
       (project) => project.id === supabaseConn.selectedProjectId,
     );
-    const supabaseAlert = useStore(workbenchStore.supabaseAlert);
-    const { activeProviders, promptId, autoSelectTemplate, contextOptimizationEnabled } = useSettings();
+  const supabaseAlert = useStore(workbenchStore.supabaseAlert);
+  const { activeProviders, promptId, autoSelectTemplate, contextOptimizationEnabled } = useSettings();
+  const { rules, setRules } = useUserRules();
 
     const [model, setModel] = useState(() => {
       const savedModel = Cookies.get('selectedModel');
@@ -170,6 +172,7 @@ export const ChatImpl = memo(
         promptId,
         contextOptimization: contextOptimizationEnabled,
         chatMode,
+        userRules: rules,
         supabase: {
           isConnected: supabaseConn.isConnected,
           hasSelectedProject: !!selectedProject,
@@ -568,6 +571,8 @@ export const ChatImpl = memo(
         data={chatData}
         chatMode={chatMode}
         setChatMode={setChatMode}
+        rules={rules}
+        setRules={setRules}
         append={append}
       />
     );

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -53,9 +53,12 @@ interface ChatBoxProps {
   enhancePrompt?: (() => void) | undefined;
   chatMode?: 'discuss' | 'build';
   setChatMode?: (mode: 'discuss' | 'build') => void;
+  rules?: string;
+  setRules?: (rules: string) => void;
 }
 
 export const ChatBox: React.FC<ChatBoxProps> = (props) => {
+  const [showRules, setShowRules] = React.useState(false);
   return (
     <div
       className={classNames(
@@ -116,6 +119,14 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
           />
         )}
       </ClientOnly>
+      {showRules && (
+        <textarea
+          className="w-full p-2 mb-2 rounded-md border border-[#444] bg-gray-800 text-gray-200 text-sm"
+          placeholder="Additional rules"
+          value={props.rules}
+          onChange={(e) => props.setRules?.(e.target.value)}
+        />
+      )}
       <div
         className={classNames('relative border border-[#444] rounded-md bg-gray-900/30 backdrop-blur-md')}
       >
@@ -226,6 +237,13 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
               ) : (
                 <div className="i-bolt:stars text-gray-200 text-xl"></div>
               )}
+            </IconButton>
+            <IconButton
+              title="Rules"
+              className="transition-all border border-[#444]"
+              onClick={() => setShowRules(!showRules)}
+            >
+              <div className="i-ph:note-pencil text-gray-200 text-xl" />
             </IconButton>
 
             <SpeechRecognitionButton

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -21,6 +21,7 @@ export interface StreamingOptions extends Omit<Parameters<typeof _streamText>[0]
       supabaseUrl?: string;
     };
   };
+  userRules?: string;
 }
 
 const logger = createScopedLogger('stream-text');
@@ -126,6 +127,14 @@ export async function streamText(props: {
         credentials: options?.supabaseConnection?.credentials || undefined,
       },
     }) ?? getSystemPrompt();
+
+  if (options?.userRules && options.userRules.trim()) {
+    systemPrompt = `${systemPrompt}
+
+USER RULES:
+${options.userRules}
+`;
+  }
 
   if (chatMode === 'build' && contextFiles && contextOptimization) {
     const codeContext = createFilesContext(contextFiles, true);

--- a/app/lib/hooks/useUserRules.ts
+++ b/app/lib/hooks/useUserRules.ts
@@ -1,0 +1,12 @@
+import { useStore } from '@nanostores/react';
+import { userRulesStore, updateUserRules } from '~/lib/stores/userRules';
+
+export function useUserRules() {
+  const rules = useStore(userRulesStore);
+
+  const setRules = (newRules: string) => {
+    updateUserRules(newRules);
+  };
+
+  return { rules, setRules };
+}

--- a/app/lib/stores/userRules.ts
+++ b/app/lib/stores/userRules.ts
@@ -1,0 +1,16 @@
+import { atom } from 'nanostores';
+
+const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('userRules') || '' : '';
+
+export const userRulesStore = atom<string>(stored);
+
+export const updateUserRules = (rules: string) => {
+  userRulesStore.set(rules);
+  if (typeof localStorage !== 'undefined') {
+    if (rules) {
+      localStorage.setItem('userRules', rules);
+    } else {
+      localStorage.removeItem('userRules');
+    }
+  }
+};

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -37,12 +37,13 @@ function parseCookies(cookieHeader: string): Record<string, string> {
 }
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
-  const { messages, files, promptId, contextOptimization, supabase, chatMode } = await request.json<{
+  const { messages, files, promptId, contextOptimization, supabase, chatMode, userRules } = await request.json<{
     messages: Messages;
     files: any;
     promptId?: string;
     contextOptimization: boolean;
     chatMode: 'discuss' | 'build';
+    userRules?: string;
     supabase?: {
       isConnected: boolean;
       hasSelectedProject: boolean;
@@ -190,6 +191,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
 
         const options: StreamingOptions = {
           supabaseConnection: supabase,
+          userRules,
           toolChoice: 'none',
           onFinish: async ({ text: content, finishReason, usage }) => {
             logger.debug('usage', JSON.stringify(usage));


### PR DESCRIPTION
## Summary
- add `userRules` store and hook
- add rules textarea and toggle button in the chat box
- send user rules with chat messages and append them in system prompt

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dce5b7840832bab3706d6085e2ef3