### PR TITLE
Add custom rules feature

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -74,6 +74,8 @@ interface BaseChatProps {
   chatMode?: 'discuss' | 'build';
   setChatMode?: (mode: 'discuss' | 'build') => void;
   append?: (message: Message) => void;
+  userRules: string;
+  setUserRules: (rules: string) => void;
 }
 
 export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
@@ -115,6 +117,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       chatMode,
       setChatMode,
       append,
+      userRules,
+      setUserRules,
     },
     ref,
   ) => {
@@ -454,6 +458,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   handleFileUpload={handleFileUpload}
                   chatMode={chatMode}
                   setChatMode={setChatMode}
+                  userRules={userRules}
+                  setUserRules={setUserRules}
                 />
               </div>
             </StickToBottom>

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -149,6 +149,9 @@ export const ChatImpl = memo(
     const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
 
     const [chatMode, setChatMode] = useState<'discuss' | 'build'>('build');
+    const [userRules, setUserRules] = useState(() => {
+      return Cookies.get('userRules') || '';
+    });
     const {
       messages,
       isLoading,
@@ -170,6 +173,7 @@ export const ChatImpl = memo(
         promptId,
         contextOptimization: contextOptimizationEnabled,
         chatMode,
+        userRules,
         supabase: {
           isConnected: supabaseConn.isConnected,
           hasSelectedProject: !!selectedProject,
@@ -506,6 +510,10 @@ export const ChatImpl = memo(
       Cookies.set('selectedProvider', newProvider.name, { expires: 30 });
     };
 
+    useEffect(() => {
+      Cookies.set('userRules', userRules, { expires: 30 });
+    }, [userRules]);
+
     return (
       <BaseChat
         ref={animationScope}
@@ -569,6 +577,8 @@ export const ChatImpl = memo(
         chatMode={chatMode}
         setChatMode={setChatMode}
         append={append}
+        userRules={userRules}
+        setUserRules={setUserRules}
       />
     );
   },

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -15,6 +15,7 @@ import { ExportChatButton } from '~/components/chat/chatExportAndImport/ExportCh
 import { SupabaseConnection } from './SupabaseConnection';
 import { ExpoQrModal } from '~/components/workbench/ExpoQrModal';
 import type { ProviderInfo } from '~/types/model';
+import { UserRulesPopover } from './UserRulesPopover';
 
 interface ChatBoxProps {
   isModelSettingsCollapsed: boolean;
@@ -53,6 +54,8 @@ interface ChatBoxProps {
   enhancePrompt?: (() => void) | undefined;
   chatMode?: 'discuss' | 'build';
   setChatMode?: (mode: 'discuss' | 'build') => void;
+  userRules: string;
+  setUserRules: (rules: string) => void;
 }
 
 export const ChatBox: React.FC<ChatBoxProps> = (props) => {
@@ -234,6 +237,7 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
               onStop={props.stopListening}
               disabled={props.isStreaming}
             />
+            <UserRulesPopover rules={props.userRules} setRules={props.setUserRules} />
             {props.chatStarted && (
               <IconButton
                 title="Discuss"

--- a/app/components/chat/UserRulesPopover.tsx
+++ b/app/components/chat/UserRulesPopover.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Popover from '~/components/ui/Popover';
+import { IconButton } from '~/components/ui/IconButton';
+
+interface UserRulesPopoverProps {
+  rules: string;
+  setRules: (rules: string) => void;
+}
+
+export const UserRulesPopover: React.FC<UserRulesPopoverProps> = ({ rules, setRules }) => {
+  return (
+    <Popover
+      side="top"
+      align="start"
+      trigger={
+        <IconButton title="Custom Rules" className="transition-all border border-[#444]">
+          <div className="i-ph:note-pencil text-gray-200 text-xl" />
+        </IconButton>
+      }
+    >
+      <textarea
+        value={rules}
+        onChange={(e) => setRules(e.target.value)}
+        placeholder="Add custom rules..."
+        className="w-64 h-32 p-2 rounded-md bg-gray-900 text-gray-200 border border-[#444] text-sm resize-none"
+      />
+    </Popover>
+  );
+};

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -38,6 +38,7 @@ export async function streamText(props: {
   summary?: string;
   messageSliceId?: number;
   chatMode?: 'discuss' | 'build';
+  userRules?: string;
 }) {
   const {
     messages,
@@ -51,6 +52,7 @@ export async function streamText(props: {
     contextFiles,
     summary,
     chatMode,
+    userRules,
   } = props;
   let currentModel = DEFAULT_MODEL;
   let currentProvider = DEFAULT_PROVIDER.name;
@@ -126,6 +128,10 @@ export async function streamText(props: {
         credentials: options?.supabaseConnection?.credentials || undefined,
       },
     }) ?? getSystemPrompt();
+
+  if (userRules && userRules.trim().length > 0) {
+    systemPrompt = `${systemPrompt}\n\n${userRules}`;
+  }
 
   if (chatMode === 'build' && contextFiles && contextOptimization) {
     const codeContext = createFilesContext(contextFiles, true);

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -37,12 +37,13 @@ function parseCookies(cookieHeader: string): Record<string, string> {
 }
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
-  const { messages, files, promptId, contextOptimization, supabase, chatMode } = await request.json<{
+  const { messages, files, promptId, contextOptimization, supabase, chatMode, userRules } = await request.json<{
     messages: Messages;
     files: any;
     promptId?: string;
     contextOptimization: boolean;
     chatMode: 'discuss' | 'build';
+    userRules?: string;
     supabase?: {
       isConnected: boolean;
       hasSelectedProject: boolean;
@@ -252,6 +253,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               chatMode,
               summary,
               messageSliceId,
+              userRules,
             });
 
             result.mergeIntoDataStream(dataStream);
@@ -292,6 +294,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
           chatMode,
           summary,
           messageSliceId,
+          userRules,
         });
 
         (async () => {


### PR DESCRIPTION
## Summary
- allow users to specify additional rules
- send those custom rules to the backend when chatting
- apply custom rules to the system prompt
- add popover UI for rule editing on chat box

## Testing
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684dce5b7840832bab3706d6085e2ef3