### PR TITLE
Add env toggle for template selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,6 @@ VITE_GITHUB_TOKEN_TYPE=classic
 # DEFAULT_NUM_CTX=12288 # Consumes 26GB of VRAM
 # DEFAULT_NUM_CTX=6144 # Consumes 24GB of VRAM
 DEFAULT_NUM_CTX=
+
+# Set to true to disable importing starter templates
+DISABLE_STARTER_TEMPLATES=

--- a/.env.production
+++ b/.env.production
@@ -113,3 +113,6 @@ VITE_NETLIFY_ACCESS_TOKEN=
 # DEFAULT_NUM_CTX=12288 # Consumes 26GB of VRAM
 # DEFAULT_NUM_CTX=6144 # Consumes 24GB of VRAM
 DEFAULT_NUM_CTX=
+
+# Set to true to disable importing starter templates
+DISABLE_STARTER_TEMPLATES=

--- a/app/utils/selectStarterTemplate.ts
+++ b/app/utils/selectStarterTemplate.ts
@@ -80,7 +80,20 @@ const parseSelectedTemplate = (llmOutput: string): { template: string; title: st
   }
 };
 
-export const selectStarterTemplate = async (options: { message: string; model: string; provider: ProviderInfo }) => {
+export const selectStarterTemplate = async (options: {
+  message: string;
+  model: string;
+  provider: ProviderInfo;
+}) => {
+  // Allow disabling template selection entirely via environment variable
+  const disableTemplates =
+    process.env.DISABLE_STARTER_TEMPLATES === 'true' ||
+    import.meta.env?.VITE_DISABLE_STARTER_TEMPLATES === 'true';
+
+  if (disableTemplates) {
+    return { template: 'blank', title: '' };
+  }
+
   const { message, model, provider } = options;
   const requestBody = {
     message,

--- a/docs/disabling-templates.txt
+++ b/docs/disabling-templates.txt
@@ -1,0 +1,3 @@
+# Disabling Starter Templates
+
+If you prefer generating projects entirely from scratch without importing any starter templates, set the environment variable `DISABLE_STARTER_TEMPLATES` to `true` in your `.env` file. When enabled, the app skips template selection and initializes an empty project based solely on your instructions.


### PR DESCRIPTION
## Summary
- allow disabling starter templates with `DISABLE_STARTER_TEMPLATES`
- document how to disable templates

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684dda3edd24832bbd82c8636443cc15